### PR TITLE
Pull version from pom.xml instead of hardcoding it.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,16 @@
 
     <groupId>dev.sim0n</groupId>
     <artifactId>caesium</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.8</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <build>
+        <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -91,6 +98,4 @@
             <version>0.44</version>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/src/main/java/dev/sim0n/caesium/Caesium.java
+++ b/src/main/java/dev/sim0n/caesium/Caesium.java
@@ -5,13 +5,13 @@ import dev.sim0n.caesium.manager.ClassManager;
 import dev.sim0n.caesium.manager.MutatorManager;
 import dev.sim0n.caesium.util.ByteUtil;
 import dev.sim0n.caesium.util.Dictionary;
+import dev.sim0n.caesium.util.VersionUtil;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
-import java.io.PrintStream;
 import java.security.SecureRandom;
 import java.util.Optional;
 
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @Getter
 public class Caesium {
-    public static final String VERSION = "1.0.7";
+    public static final String VERSION = VersionUtil.getVersion();
 
     private static final String SEPARATOR = Strings.repeat("-", 30);
 

--- a/src/main/java/dev/sim0n/caesium/util/VersionUtil.java
+++ b/src/main/java/dev/sim0n/caesium/util/VersionUtil.java
@@ -1,0 +1,27 @@
+package dev.sim0n.caesium.util;
+
+import dev.sim0n.caesium.Caesium;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class VersionUtil {
+
+    public static String getVersion() {
+        try (InputStream is = Caesium.class.getResourceAsStream("/META-INF/maven/dev.sim0n/caesium/pom.properties")) {
+            if (is != null) {
+                Properties properties = new Properties();
+                properties.load(is);
+
+                String pomVersion = properties.getProperty("version");
+
+                if (pomVersion != null) {
+                    return pomVersion;
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return "Unknown";
+    }
+}

--- a/src/main/java/dev/sim0n/caesium/util/VersionUtil.java
+++ b/src/main/java/dev/sim0n/caesium/util/VersionUtil.java
@@ -1,14 +1,16 @@
 package dev.sim0n.caesium.util;
 
 import dev.sim0n.caesium.Caesium;
+import lombok.experimental.UtilityClass;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+@UtilityClass
 public class VersionUtil {
 
-    public static String getVersion() {
+    public String getVersion() {
         try (InputStream is = Caesium.class.getResourceAsStream("/META-INF/maven/dev.sim0n/caesium/pom.properties")) {
             if (is != null) {
                 Properties properties = new Properties();


### PR DESCRIPTION
What the title says. This fixes the version in the target jar's name (previously 1.0-SNAPSHOT) and also makes it easier to bump versions. Also added some things to pom.xml.